### PR TITLE
Phony change to trigger image rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,3 @@ get-image-name:
 
 get-image-repository:
 	@echo $(REPOSITORY)
-


### PR DESCRIPTION
[Latest image build failed](https://ci.centos.org/job/devtools-fabric8-analytics-worker-base-f8a-build-master/11/console) due to

```
Pulling repository registry.centos.org/centos/centos
Error: image centos/centos:7 not found
```