### PR TITLE
Install fche's pcp for pmcd metrics collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN mkdir -p /tmp/install_deps
 
 # https://copr.fedorainfracloud.org/coprs/jpopelka/mercator/
 # https://copr.fedorainfracloud.org/coprs/jpopelka/python-brewutils/
-COPY hack/_copr_jpopelka-mercator.repo hack/_copr_jpopelka-python-brewutils.repo /etc/yum.repos.d/
+# https://copr.fedorainfracloud.org/coprs/fche/pcp/
+COPY hack/_copr_jpopelka-mercator.repo hack/_copr_jpopelka-python-brewutils.repo hack/_copr_fche_pcp.repo /etc/yum.repos.d/
 
 # Install RPM dependencies
 COPY hack/install_deps_rpm.sh /tmp/install_deps/
@@ -68,6 +69,11 @@ RUN pip3 install -r /tmp/install_deps/py23requirements.txt
 
 # Install gofedlib needed for Go support
 RUN pip2 install --egg git+https://github.com/gofed/gofedlib.git@18e0ce72d2c7bcbe3b19c20378f602633292eedf
+
+# Create & set pcp dirs
+RUN mkdir -p /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp  && \
+    chgrp -R root /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
+    chmod -R g+rwX /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
 
 # Import RH CA cert (not accessible outside RH)
 #COPY hack/import_RH_CA_cert.sh /tmp/install_deps/

--- a/hack/_copr_fche_pcp.repo
+++ b/hack/_copr_fche_pcp.repo
@@ -1,0 +1,10 @@
+[fche-pcp]
+name=Copr repo for pcp owned by fche
+baseurl=https://copr-be.cloud.fedoraproject.org/results/fche/pcp/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/fche/pcp/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/hack/install_deps_rpm.sh
+++ b/hack/install_deps_rpm.sh
@@ -48,6 +48,8 @@ UNKNOWN="koji rpmdevtools nodejs-packaging"
 
 GOLANG_SUPPORT="golang"
 
+# for pcp pmcd metrics collector
+PCP="pcp"
 
 # Install all RPM deps
 yum install -y --setopt=tsflags=nodocs ${BUILD} ${REQUIREMENTS_TXT} \
@@ -55,4 +57,4 @@ yum install -y --setopt=tsflags=nodocs ${BUILD} ${REQUIREMENTS_TXT} \
                 ${DIGESTER} ${LINGUIST} \
                 ${OSCRYPTOCATCHER} ${CSMOCK_TASK_DEPS} \
                 ${BD_DEPS} ${BREWUTILS} ${MERCATOR} ${CODE_METRICS} \
-                ${DEPENDENCY_CHECK} ${GOLANG_SUPPORT}
+                ${DEPENDENCY_CHECK} ${GOLANG_SUPPORT} ${PCP}


### PR DESCRIPTION
As suggested [here](https://github.com/openshiftio/openshift.io/issues/732#issuecomment-345007310), this PR installs PCP into base image
and https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/444 can then just add the `worker+pmcd.sh` script.

@fche BTW the `pcp-selinux` %post scriptlet fails:
```
Installing : pcp-selinux-3.12.2-0.201711171354.git3659ca2e.el7.cent   127/273 
Failed to resolve typeattributeset statement at /etc/selinux/targeted/tmp/modules/400/pcpupstream/cil:1
semodule:  Failed!
warning: %post(pcp-selinux-3.12.2-0.201711171354.git3659ca2e.el7.centos.x86_64) scriptlet failed, exit status 1
Non-fatal POSTIN scriptlet failure in rpm package pcp-selinux-3.12.2-0.201711171354.git3659ca2e.el7.centos.x86_64
```