### PR TITLE
Revert to installing gofedlib from git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN yum install -y epel-release && \
 # Work-arounds & hacks:
 # 'pip install --upgrade wheel': http://stackoverflow.com/questions/14296531
 RUN pip3 install --upgrade pip && pip install --upgrade wheel && \
-    pip3 install alembic psycopg2 gofedlib
+    pip3 install alembic psycopg2
 
 # Install javascript deps
 COPY hack/install_deps_npm.sh /tmp/install_deps/
@@ -51,6 +51,9 @@ RUN /tmp/install_deps/install_scancode.sh
 COPY ./hack/py23requirements.txt /tmp/install_deps/
 RUN pip2 install -r /tmp/install_deps/py23requirements.txt
 RUN pip3 install -r /tmp/install_deps/py23requirements.txt
+
+# Install gofedlib needed for Go support
+RUN pip2 install --egg git+https://github.com/gofed/gofedlib.git@18e0ce72d2c7bcbe3b19c20378f602633292eedf
 
 # Create & set pcp dirs
 RUN mkdir -p /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp  && \

--- a/hack/install_deps_rpm.sh
+++ b/hack/install_deps_rpm.sh
@@ -3,10 +3,13 @@
 # Required by Dockerfile or any built-time script in hack/
 BUILD="python34-pip python2-pip wget"
 
-# We need postgresql-devel and python3-devel for psycopg2 listed in f8a_worker/requirements.txt
-# We cannot use requests from PyPI since it does not allow us to use own certificates
-# python3-pycurl is needed for Amazon SQS (boto lib), we need Fedora's rpm - installing it from pip results in NSS errors
-REQUIREMENTS_TXT='postgresql-devel python34-devel libxml2-devel libxslt-devel python34-requests python34-pycurl patch'
+# - We need postgresql-devel and python3-devel for psycopg2 listed in f8a_worker/requirements.txt
+# - We cannot use requests from PyPI since it does not allow us to use own certificates
+#   python3-pycurl is needed for Amazon SQS (boto lib), we need Fedora's rpm - installing it from pip results in NSS errors
+# - Installing python-requests is a work-around for a conflict which happens when you do
+#   'pip install requests; yum install python-requests' (while it's OK if you swap those)
+#   It can be removed once gofedlib runs on Python 3.
+REQUIREMENTS_TXT='postgresql-devel python34-devel libxml2-devel libxslt-devel python34-requests python-requests python34-pycurl patch'
 
 # hack/run-db-migrations.sh
 DB_MIGRATIONS='postgresql'


### PR DESCRIPTION
It's not Python 3 ready and installing it with `pip2` (from pypi) also mostly fails on centos.