### PR TITLE
Deploy on RHEL based container

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,20 +1,12 @@
-FROM registry.access.redhat.com/rhel7
+FROM prod.registry.devshift.net/osio-prod/base/fabric8-analytics-worker:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
 
 ENV LANG=en_US.UTF-8 \
     JAVANCSS_PATH='/opt/javancss/' \
     OWASP_DEP_CHECK_PATH='/opt/dependency-check/' \
     OWASP_DEP_CHECK_SUPPRESS_PATH='/opt/dependency-check/suppress/' \
     SCANCODE_PATH='/opt/scancode-toolkit/'
-
-# https://copr.fedorainfracloud.org/coprs/jpopelka/mercator/
-# https://copr.fedorainfracloud.org/coprs/fche/pcp/
-COPY hack/_copr_jpopelka-mercator.repo hack/_copr_fche_pcp.repo /etc/yum.repos.d/
-
-# Install RPM dependencies
-COPY hack/install_deps_rpm.sh /tmp/install_deps/
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    /tmp/install_deps/install_deps_rpm.sh && \
-    yum clean all
 
 # Work-arounds & hacks:
 # 'pip install --upgrade wheel': http://stackoverflow.com/questions/14296531

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,10 @@
 ifeq ($(TARGET), rhel)
     DOCKERFILE := Dockerfile.rhel
-
-    ifndef DOCKER_REGISTRY
-        $(error DOCKER_REGISTRY is not set)
-    endif
-
-    REGISTRY := $(DOCKER_REGISTRY)
 else
     DOCKERFILE := Dockerfile
-    REGISTRY?=registry.devshift.net
 endif
+
+REGISTRY?=registry.devshift.net
 REPOSITORY?=fabric8-analytics/f8a-worker-base
 DEFAULT_TAG=latest
 

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -4,6 +4,8 @@ set -ex
 
 . cico_setup.sh
 
+docker_login
+
 build_image
 
 WORKER_BASE_IMAGE=$(make get-image-name) ./tests/run_integration_tests.sh

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -4,6 +4,8 @@ set -ex
 
 . cico_setup.sh
 
+docker_login
+
 build_image
 
 WORKER_BASE_IMAGE=$(make get-image-name) ./tests/run_integration_tests.sh

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -ex
 
+REGISTRY="push.registry.devshift.net"
+
 load_jenkins_vars() {
     if [ -e "jenkins-env" ]; then
         cat jenkins-env \
@@ -27,45 +29,38 @@ tag_push() {
     docker push ${target}
 }
 
+docker_login() {
+    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
+        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+    else
+        echo "Could not login, missing credentials for the registry"
+        exit 1
+    fi
+}
+
 push_image() {
     local image_name
     local image_repository
     local short_commit
-    local push_registry
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
     short_commit=$(git rev-parse --short=7 HEAD)
 
     if [ "$TARGET" = "rhel" ]; then
-        if [ -z "${DOCKER_REGISTRY}" ]; then
-            echo "DOCKER_REGISTRY must be defined for TARGET=rhel" >&2
-            exit 1
-        fi
-
-        push_registry="${DOCKER_REGISTRY}"
+        IMAGE_URL="${REGISTRY}/osio-prod/${image_repository}"
     else
-        push_registry="push.registry.devshift.net"
-    fi
-
-    if [ "$TARGET" != "rhel" ]; then
-        # login first
-        if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-            docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}
-        else
-            echo "Could not login, missing credentials for the registry"
-            exit 1
-        fi
+        IMAGE_URL="${REGISTRY}/${image_repository}"
     fi
 
     if [ -n "${ghprbPullId}" ]; then
         # PR build
         pr_id="SNAPSHOT-PR-${ghprbPullId}"
-        tag_push ${push_registry}/${image_repository}:${pr_id} ${image_name}
-        tag_push ${push_registry}/${image_repository}:${pr_id}-${short_commit} ${image_name}
+        tag_push ${IMAGE_URL}:${pr_id} ${image_name}
+        tag_push ${IMAGE_URL}:${pr_id}-${short_commit} ${image_name}
     else
         # master branch build
-        tag_push ${push_registry}/${image_repository}:latest ${image_name}
-        tag_push ${push_registry}/${image_repository}:${short_commit} ${image_name}
+        tag_push ${IMAGE_URL}:latest ${image_name}
+        tag_push ${IMAGE_URL}:${short_commit} ${image_name}
     fi
 
     echo 'CICO: Image pushed, ready to update deployed app'


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

As part of an effort to migrate the services running in OSIO from CentOS
to RHEL, we are ready to push out the RHEL based image for this service
into staging.

This PR includes a new RHEL based dockerfile for the deployment of the service.
This dockerfile will be built when this variable is set: TARGET=rhel. The build
scripts have been adapted to take this into consideration, and to push the image
to different namespaces if the TARGET is rhel or not.

Currently the deployment builds happen on empty baremetal machines. The build
script will be executed a second time to build and push the deployment file if
TARGET=rhel, so some changes in the build script are to ensure that it will work
if executed a second time.