### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/fabric8-analytics-worker:latest
+FROM quay.io/openshiftio/rhel-base-fabric8-analytics-worker:latest
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 

--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,8 @@ test: fast-docker-build
 get-image-name:
 	@echo $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG)
 
+get-image-name-base:
+	@echo $(REGISTRY)/$(REPOSITORY)
+
 get-image-repository:
 	@echo $(REPOSITORY)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 ifeq ($(TARGET), rhel)
     DOCKERFILE := Dockerfile.rhel
+    REPOSITORY ?= openshiftio/rhel-fabric8-analytics-f8a-worker-base
 else
     DOCKERFILE := Dockerfile
+    REPOSITORY ?= openshiftio/fabric8-analytics-f8a-worker-base
 endif
 
-REGISTRY?=registry.devshift.net
-REPOSITORY?=fabric8-analytics/f8a-worker-base
+REGISTRY?=quay.io
 DEFAULT_TAG=latest
 
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -47,11 +47,9 @@ docker_login() {
 
 push_image() {
     local image_name
-    local image_repository
     local short_commit
 
-    image_name=$(make get-image-name)
-    image_repository=$(make get-image-repository)
+    image_name=$(make get-image-name-base)
     short_commit=$(git rev-parse --short=$DEVSHIFT_TAG_LEN HEAD)
 
     if [ -n "${ghprbPullId}" ]; then

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-REGISTRY="push.registry.devshift.net"
+REGISTRY="quay.io"
 
 load_jenkins_vars() {
     if [ -e "jenkins-env.json" ]; then

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -3,12 +3,19 @@
 REGISTRY="push.registry.devshift.net"
 
 load_jenkins_vars() {
-    if [ -e "jenkins-env" ]; then
-        cat jenkins-env \
-          | grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-          | sed 's/^/export /g' \
-          > ~/.jenkins-env
-        source ~/.jenkins-env
+    if [ -e "jenkins-env.json" ]; then
+        eval "$(./env-toolkit load -f jenkins-env.json \
+                DEVSHIFT_TAG_LEN \
+                QUAY_USERNAME \
+                QUAY_PASSWORD \
+                JENKINS_URL \
+                GIT_BRANCH \
+                GIT_COMMIT \
+                BUILD_NUMBER \
+                ghprbSourceBranch \
+                ghprbActualCommit \
+                BUILD_URL \
+                ghprbPullId)"
     fi
 }
 
@@ -30,8 +37,8 @@ tag_push() {
 }
 
 docker_login() {
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+    if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+        docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} ${REGISTRY}
     else
         echo "Could not login, missing credentials for the registry"
         exit 1
@@ -42,25 +49,20 @@ push_image() {
     local image_name
     local image_repository
     local short_commit
+
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
-    short_commit=$(git rev-parse --short=7 HEAD)
-
-    if [ "$TARGET" = "rhel" ]; then
-        IMAGE_URL="${REGISTRY}/osio-prod/${image_repository}"
-    else
-        IMAGE_URL="${REGISTRY}/${image_repository}"
-    fi
+    short_commit=$(git rev-parse --short=$DEVSHIFT_TAG_LEN HEAD)
 
     if [ -n "${ghprbPullId}" ]; then
         # PR build
         pr_id="SNAPSHOT-PR-${ghprbPullId}"
-        tag_push ${IMAGE_URL}:${pr_id} ${image_name}
-        tag_push ${IMAGE_URL}:${pr_id}-${short_commit} ${image_name}
+        tag_push ${image_name}:${pr_id} ${image_name}
+        tag_push ${image_name}:${pr_id}-${short_commit} ${image_name}
     else
         # master branch build
-        tag_push ${IMAGE_URL}:latest ${image_name}
-        tag_push ${IMAGE_URL}:${short_commit} ${image_name}
+        tag_push ${image_name}:latest ${image_name}
+        tag_push ${image_name}:${short_commit} ${image_name}
     fi
 
     echo 'CICO: Image pushed, ready to update deployed app'


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env